### PR TITLE
Fix LiChess client turn handling

### DIFF
--- a/src/OcpCore.Engine.LiChessClient/Client/LiChessClient.cs
+++ b/src/OcpCore.Engine.LiChessClient/Client/LiChessClient.cs
@@ -238,7 +238,7 @@ public sealed class LiChessClient : IDisposable
             lastMove = moves[^1];
         }
 
-        if (_core.Player == Colour.White && engineIsWhite)
+        if (_core.CurrentPlayer == _core.Player)
         {
             OutputLine("&NL;  &Cyan;Thinking&White;...");
             
@@ -282,16 +282,21 @@ public sealed class LiChessClient : IDisposable
         }
         else
         {
+            if (moves.Length == 0)
+            {
+                return 0;
+            }
+
             _core.MakeMove(lastMove);
 
             OutputLine($"&NL;  &Green;Opponent&White;: {lastMove}");
-                        
+
             OutputLine();
-            
+
             _core.OutputBoard(! engineIsWhite);
 
             OutputLine("&NL;  &Cyan;Thinking&White;...");
-            
+
             var engineMove = _core.GetMove(Depth);
 
             // ReSharper disable once SwitchStatementMissingSomeEnumCasesNoDefault

--- a/src/OcpCore.Engine/Core.cs
+++ b/src/OcpCore.Engine/Core.cs
@@ -42,6 +42,8 @@ public sealed class Core : IDisposable
 
     // ReSharper disable once ConvertToAutoPropertyWhenPossible
     public Colour Player => _engineColour;
+
+    public Colour CurrentPlayer => _game.State.Player;
     
     public (Colour Colour, Kind Kind) this[string position] 
     {


### PR DESCRIPTION
## Summary
- expose `Core.CurrentPlayer`
- only move when it's the engine's turn in LiChess client
- ignore empty move stream when engine plays black

## Testing
- `dotnet test src/OcpCore.Engine.Tests/OcpCore.Engine.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68656af13a508322aac2381cb50aa68d